### PR TITLE
added the session to common handler

### DIFF
--- a/aodn_cloud_optimised/lib/CommonHandler.py
+++ b/aodn_cloud_optimised/lib/CommonHandler.py
@@ -9,6 +9,7 @@ from coiled import Cluster
 from dask.distributed import Client
 from dask.distributed import LocalCluster
 from jsonschema import validate, ValidationError
+from aiobotocore.session import AioSession
 
 from .config import load_variable_from_config, load_dataset_config
 from .logging import get_logger
@@ -91,7 +92,8 @@ class CommonHandler:
         self.cluster_options = self.dataset_config.get("cluster_options", None)
 
         self.s3_fs = s3fs.S3FileSystem(
-            anon=False
+            anon=False,
+            session=kwargs.get("s3fs_session")
         )  # variable overwritten in unittest to use moto server
 
     def __enter__(self):
@@ -488,12 +490,13 @@ def _get_generic_handler_class(dataset_config):
 
 
 def cloud_optimised_creation(
-    s3_file_uri_list: List[str], dataset_config: dict, **kwargs
+        s3_file_uri_list: List[str], dataset_config: dict, s3fs_session: AioSession, **kwargs
 ) -> None:
     """
     Iterate through a list of s3 file paths and create Cloud Optimised files for each file.
 
     Args:
+        s3fs_session: An aiobotocore authenticated session
         s3_file_uri_list (List[str]): List of file paths to process.
         dataset_config (dictionary): dataset configuration. Check config/dataset_template.json for example
         **kwargs: Additional keyword arguments for customization.
@@ -530,6 +533,7 @@ def cloud_optimised_creation(
             load_variable_from_config("ROOT_PREFIX_CLOUD_OPTIMISED_PATH"),
         ),
         "cluster_mode": kwargs.get("cluster_mode", "local"),
+        "s3fs_session": s3fs_session
     }
 
     # Filter out None values


### PR DESCRIPTION
This is so we can run it on our prefect infra. It should work if you don't have a aws_profile env var set and then:

```
    cloud_optimised_creation(
        [nc_obj_ls[0]],
        dataset_config=dataset_config,
        s3fs_session=aiobotocore.session.AioSession(profile=prefect_config['aws_profile']),
        clear_existing_data=True,  # this will delete existing data, be cautious! If testing change the paths below
        # optimised_bucket_name="imos-data-lab-optimised",  # optional, default value in config/common.json
        root_prefix_cloud_optimised_path="cloud_optimised/prefect_testing",
        # optional, default value in config/common.json
        cluster_mode='local',
    )
```