### PR TITLE
fix FrozenMappingWarningOnValuesAccess

### DIFF
--- a/aodn_cloud_optimised/lib/AnmnHourlyTsHandler.py
+++ b/aodn_cloud_optimised/lib/AnmnHourlyTsHandler.py
@@ -35,7 +35,7 @@ class AnmnHourlyTsHandler(GenericHandler):
             assert set(ds.dims) == {
                 "OBSERVATION",
                 "INSTRUMENT",
-            }, f"Unexpected dimensions {ds.dims.keys()}"
+            }, f"Unexpected dimensions {set(ds.dims)}"
 
             df = ds.drop_dims("INSTRUMENT").to_dataframe()
             instrument_info = ds.drop_dims("OBSERVATION").to_dataframe()


### PR DESCRIPTION
The issue arises because ds.dims in xarray returns a Frozen object, and accessing its keys() directly triggers the FrozenMappingWarningOnValuesAccess.

This change will probably be needed in other places.

I think perhaps accessing keys is too be deprecated?

```python
class FrozenMappingWarningOnValuesAccess(Frozen[K, V]):
    """
    Class which behaves like a Mapping but warns if the values are accessed.

    Temporary object to aid in deprecation cycle of `Dataset.dims` (see GH issue #8496).
    `Dataset.dims` is being changed from returning a mapping of dimension names to lengths to just
    returning a frozen set of dimension names (to increase consistency with `DataArray.dims`).
    This class retains backwards compatibility but raises a warning only if the return value
    of ds.dims is used like a dictionary (i.e. it doesn't raise a warning if used in a way that
    would also be valid for a FrozenSet, e.g. iteration).
    """
```