### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
-*.ipynb linguist-vendored
+# Override jupyter in Github language stats for more accurate estimate of repo code languages
+# reference: https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code
+*.ipynb linguist-generated


### PR DESCRIPTION
This change to ignore `Jupyter notebook` from being identified as the repo's language (since notebook files are way more lengthy comparing to the Python files, and fool the GitHub repository's language analyser). This might be helpful when people exploring for solutions by GitHub search function, and also simply because the repo's language should be `Python`. Similar issue in the wild: https://github.com/github-linguist/linguist/issues/3316

it takes sometimes to see the actual effect btw.