### PR TITLE
options to provide prefect s3 bucket blocks and to not use a cluster

### DIFF
--- a/aodn_cloud_optimised/bin/generic_cloud_optimised_creation.py
+++ b/aodn_cloud_optimised/bin/generic_cloud_optimised_creation.py
@@ -38,6 +38,7 @@ Arguments:
 import argparse
 from importlib.resources import files
 
+from aodn_cloud_optimised.lib import cluster_lib
 from aodn_cloud_optimised.lib.CommonHandler import cloud_optimised_creation
 from aodn_cloud_optimised.lib.config import (
     load_variable_from_config,
@@ -91,9 +92,10 @@ def main():
     )
     parser.add_argument(
         "--cluster-mode",
-        default="local",
+        type=cluster_lib.parse_cluster_mode,
+        default=None,
         choices=["local", "remote"],
-        help="Cluster mode to use. Options: 'local' or 'remote'. Default is 'local'.",
+        help="Cluster mode to use. Options: 'local' or 'remote'. Default is None.",
     )
 
     parser.add_argument(

--- a/aodn_cloud_optimised/config/common.json
+++ b/aodn_cloud_optimised/config/common.json
@@ -1,7 +1,7 @@
 {
   "BUCKET_RAW_DEFAULT": "imos-data",
   "BUCKET_OPTIMISED_DEFAULT": "aodn-cloud-optimised",
-  "ROOT_PREFIX_CLOUD_OPTIMISED_PATH": "",
+  "ROOT_PREFIX_CLOUD_OPTIMISED_PATH": "prefect_testing",
   "BUCKET_INTEGRATION_TESTING_RAW_DEFAULT": "imos-data",
   "BUCKET_INTEGRATION_TESTING_OPTIMISED_DEFAULT": "imos-data-lab-optimised",
   "ROOT_PREFIX_CLOUD_OPTIMISED_INTEGRATION_TESTING_PATH": "cloud_optimised/integration_testing"

--- a/aodn_cloud_optimised/config/common.json
+++ b/aodn_cloud_optimised/config/common.json
@@ -1,7 +1,7 @@
 {
   "BUCKET_RAW_DEFAULT": "imos-data",
   "BUCKET_OPTIMISED_DEFAULT": "aodn-cloud-optimised",
-  "ROOT_PREFIX_CLOUD_OPTIMISED_PATH": "prefect_testing",
+  "ROOT_PREFIX_CLOUD_OPTIMISED_PATH": "",
   "BUCKET_INTEGRATION_TESTING_RAW_DEFAULT": "imos-data",
   "BUCKET_INTEGRATION_TESTING_OPTIMISED_DEFAULT": "imos-data-lab-optimised",
   "ROOT_PREFIX_CLOUD_OPTIMISED_INTEGRATION_TESTING_PATH": "cloud_optimised/integration_testing"

--- a/aodn_cloud_optimised/lib/CommonHandler.py
+++ b/aodn_cloud_optimised/lib/CommonHandler.py
@@ -100,7 +100,6 @@ class CommonHandler:
         if optimised_bucket:
             self.optimised_bucket_name = optimised_bucket.bucket_name
 
-
         self.cloud_optimised_output_path = (
             PureS3Path.from_uri(f"s3://{self.optimised_bucket_name}")
             .joinpath(

--- a/aodn_cloud_optimised/lib/cluster_lib.py
+++ b/aodn_cloud_optimised/lib/cluster_lib.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class ClusterMode(Enum):
+    LOCAL = "local"
+    REMOTE = "remote"
+    NONE = None
+
+
+def parse_cluster_mode(value):
+    return ClusterMode(value)

--- a/test_aodn_cloud_optimised/test_bin_generic.py
+++ b/test_aodn_cloud_optimised/test_bin_generic.py
@@ -12,6 +12,7 @@ from moto import mock_aws
 from moto.moto_server.threaded_moto_server import ThreadedMotoServer
 
 from aodn_cloud_optimised.bin.generic_cloud_optimised_creation import main
+from aodn_cloud_optimised.lib.cluster_lib import ClusterMode
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -128,7 +129,7 @@ class TestGenericCloudOptimisedCreation(unittest.TestCase):
             dataset_config=DATASET_CONFIG_NC_ACORN_JSON,
             clear_existing_data=True,
             force_previous_parquet_deletion=False,
-            cluster_mode="local",
+            cluster_mode=ClusterMode.LOCAL,
             optimised_bucket_name=self.BUCKET_OPTIMISED_NAME,
             root_prefix_cloud_optimised_path="testing",
             bucket_raw="imos-data",


### PR DESCRIPTION
This allows for the library to be used by Prefect flows to create, append and overwrite zarr using single files and no cluster.  It also adds the ability for it to use Prefect AWS S3 Bucket blocks.  Changes should not affect previous functionality.