### PR TITLE
Add columns to limit data return

### DIFF
--- a/aodn_cloud_optimised/lib/DataQuery.py
+++ b/aodn_cloud_optimised/lib/DataQuery.py
@@ -1041,6 +1041,7 @@ class Dataset:
         lon_min=None,
         lon_max=None,
         scalar_filter=None,
+        columns=None,
     ):
         # TODO fix the whole logic as not everything is considered
 
@@ -1100,6 +1101,7 @@ class Dataset:
             self.dname,
             engine="pyarrow",
             filters=data_filter,
+            columns=columns,
             filesystem=fs.S3FileSystem(
                 region=REGION, endpoint_override=ENDPOINT_URL, anonymous=True
             ),


### PR DESCRIPTION
There is no need to return all columns in our usage, add a field to reduce data return to speed up the process