### PR TITLE
Update logging.py to preserve existing handlers

### DIFF
--- a/aodn_cloud_optimised/lib/logging.py
+++ b/aodn_cloud_optimised/lib/logging.py
@@ -101,7 +101,7 @@ def get_logger(
 
     # Console handler with color
     color_formatter = CustomFormatter(use_color=True)
-    
+
     # Check for handler types to avoid duplicates
     existing_handler_types = {type(h) for h in logger.handlers}
 


### PR DESCRIPTION
It seems something changed in Prefect 3, and additional code is now needed to stop the custom logger setup overwriting the existing handlers — including Prefect’s APILogHandler, injected via PREFECT_LOGGING_EXTRA_LOGGERS. To resolve this, I modified the get_logger() function to preserve any existing handlers.

I can now see INFO level logs in the Prefect UI when using my Prefect personal development environment.