### PR TITLE
Fix: 6712 edit filename to pass PEP427 & PEP440 guidelines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,11 +95,11 @@ jobs:
 
           poetry build -f wheel
           for f in dist/*.whl; do
-            new_name="$(echo "$f" | sed 's/\.whl$/_unfrozen.whl/')"
+            new_name="$(echo "$f" | sed -E 's/(.+)-([0-9]+\.[0-9]+\.[0-9]+)-/\\1-\\2+unfrozen-/')"
             mv "$f" "$new_name"
           done
           mkdir -p dist-unfrozen
-          cp dist/*_unfrozen.whl dist-unfrozen/
+          cp dist/*+unfrozen*.whl dist-unfrozen/
 
       - name: Delete existing tag (if any)
         run: |


### PR DESCRIPTION
pip can only install wheels that follow the PEP427/440 format. The previous filename failed and had to be renamed to install in my local environment. 

The new file name that has the correct format:
`dist/aodn_cloud_optimised-0.1.46+unfrozen-py3-none-any.whl`

The `release.yaml` has been updated. 


