### PR TITLE
vessel_co2_delayed_qc: remove underscore from filter

### DIFF
--- a/aodn_cloud_optimised/config/dataset/vessel_co2_delayed_qc.json
+++ b/aodn_cloud_optimised/config/dataset/vessel_co2_delayed_qc.json
@@ -599,7 +599,7 @@
       {
         "s3_uri": "s3://imos-data/IMOS/SOOP/SOOP-CO2/",
         "filter": [
-          ".*_FV01_.*\\.nc$"
+          ".*_FV01.*\\.nc$"
         ],
         "year_range": []
       }


### PR DESCRIPTION
This is a fix for:

`Encountered exception during execution: EventRoutingError("No matching configuration for event (key='IMOS/SOOP/SOOP-CO2/VLMJ_Investigator/2024/IN2024_V04/IMOS_SOOP-CO2_GST_20240607T122742Z_VLMJ_FV01.nc')")`

SOOP-CO2 files usually end in `...._FV01.nc`. (no underscore after FV01)